### PR TITLE
fix destruction: avoid using global static object

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1,8 +1,12 @@
 include(FetchContent)
 
 # dependencies: cuda toolkit
-find_package(CUDAToolkit REQUIRED)
+find_package(CUDAToolkit REQUIRED COMPONENTS cuda_driver)
 
+# dependencies: python
+find_package(Python REQUIRED COMPONENTS Interpreter Development)
+
+# dependencies: torch
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
 find_package(Torch MODULE REQUIRED) # This is the FindTorch.cmake
 
@@ -37,8 +41,7 @@ if (USE_EXTERNAL_PYBIND11)
   execute_process(COMMAND ${Python_EXECUTABLE} -m pybind11 --cmakedir
     OUTPUT_VARIABLE pybind11_ROOT
     OUTPUT_STRIP_TRAILING_WHITESPACE
-    COMMAND_ECHO STDOUT
-    ECHO_OUTPUT_VARIABLE)
+  )
   find_package(pybind11 CONFIG REQUIRED)
 else()
   FetchContent_Declare(pybind11

--- a/cmake/FindTorch.cmake
+++ b/cmake/FindTorch.cmake
@@ -1,12 +1,10 @@
 # dependencies: torch
 # use the current python interpreter's torch installation
 if (NOT DEFINED Torch_ROOT)
-  find_package(Python REQUIRED COMPONENTS Interpreter Development)
   execute_process(COMMAND ${Python_EXECUTABLE} "-c" "import torch;print(torch.utils.cmake_prefix_path)"
                   OUTPUT_VARIABLE Torch_ROOT
                   OUTPUT_STRIP_TRAILING_WHITESPACE
-                  COMMAND_ECHO STDOUT
-                  ECHO_OUTPUT_VARIABLE)
+  )
 endif()
 find_package(Torch CONFIG REQUIRED)
 

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -1,3 +1,3 @@
 option(TRITON_JIT_USE_EXTERNAL_JSON "whether to use external json library" OFF)
 option(TRITON_JIT_USE_EXTERNAL_FMTLIB "whether to use external fmtlib" OFF)
-option(USE_EXTERNAL_PYBIND11 "whether to use external pybind11 library" OFF)
+option(USE_EXTERNAL_PYBIND11 "whether to use external pybind11 library" ON)

--- a/include/triton_jit/jit_utils.h
+++ b/include/triton_jit/jit_utils.h
@@ -2,18 +2,15 @@
 
 #include <cstdlib>
 #include <filesystem>
+#include <mutex>
 #include <optional>
 #include <string>
 
 #include "c10/util/Logging.h"  // use torch's logging
+
 #include "torch/torch.h"
 namespace triton_jit {
 
-struct LibraryInit {
-  LibraryInit();
-};
-
-void ensure_python_initialized();
 std::string execute_command(std::string_view command);
 
 constexpr const char *to_triton_typename(c10::ScalarType t) {

--- a/include/triton_jit/jit_utils.h
+++ b/include/triton_jit/jit_utils.h
@@ -7,7 +7,6 @@
 #include <string>
 
 #include "c10/util/Logging.h"  // use torch's logging
-
 #include "torch/torch.h"
 namespace triton_jit {
 
@@ -73,7 +72,6 @@ template <typename T>
 struct triton_type : triton_type_helper<std::remove_cv_t<std::remove_reference_t<T>>> {};
 
 // path of python executable
-const char *get_python_executable();
 std::filesystem::path get_script_dir();
 const char *get_gen_static_sig_script();
 const char *get_standalone_compile_script();

--- a/src/jit_utils.cpp
+++ b/src/jit_utils.cpp
@@ -30,22 +30,6 @@ std::string execute_command(std::string_view command) {
   return result;
 }
 
-const char *get_python_executable() {
-  // TODO: use embedded python interpreter to get the executable path
-  // import sys; sys.executable
-  const static std::string python_executable_path = []() {
-    std::string python_exe;
-    const char *python_env = std::getenv("PYTHON_EXECUTABLE");
-    python_exe = python_env ? std::string(python_env) : execute_command("which python");
-    LOG(INFO) << "python executable: " << python_exe;
-    if (python_exe.empty()) {
-      throw std::runtime_error("cannot find python executable!");
-    }
-    return python_exe;
-  }();
-  return python_executable_path.c_str();
-}
-
 std::filesystem::path get_path_of_this_library() {
   // This function gives the library path of this library as runtime, similar to the $ORIGIN
   // that is used for run path (RPATH), but unfortunately, for custom dependencies (instead of linking)

--- a/src/jit_utils.cpp
+++ b/src/jit_utils.cpp
@@ -8,25 +8,8 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
-#include "pybind11/embed.h"
 
 namespace triton_jit {
-
-LibraryInit::LibraryInit() {
-  c10::initLogging();
-  ensure_python_initialized();
-}
-
-void ensure_python_initialized() {
-  namespace py = pybind11;
-  static bool initialized = false;
-  if (!initialized && !Py_IsInitialized()) {
-    static py::scoped_interpreter guard {};
-    initialized = true;
-  }
-}
-
-static LibraryInit library_init;
 
 std::string execute_command(std::string_view command) {
   std::array<char, 128> buffer;
@@ -48,6 +31,8 @@ std::string execute_command(std::string_view command) {
 }
 
 const char *get_python_executable() {
+  // TODO: use embedded python interpreter to get the executable path
+  // import sys; sys.executable
   const static std::string python_executable_path = []() {
     std::string python_exe;
     const char *python_env = std::getenv("PYTHON_EXECUTABLE");

--- a/src/triton_jit_function.cpp
+++ b/src/triton_jit_function.cpp
@@ -9,39 +9,26 @@
 #include "c10/util/Logging.h"  // use torch's logging
 #include "fmt/core.h"
 #include "nlohmann/json.hpp"
+
 #include "pybind11/embed.h"
 
 namespace triton_jit {
 std::unordered_map<std::string, TritonJITFunction> TritonJITFunction::functions_;
 
+void ensure_initialized() {
+  // When using libtriton_jit with a python C-extension, it is already initialized
+  c10::initLogging();
+  if (!Py_IsInitialized()) {
+    Py_InitializeEx(false);
+  }
+}
+
 TritonJITFunction::TritonJITFunction(std::string_view path, std::string_view name)
     : file_path_(std::string(path)), function_name_(std::string(name)) {
-  // sys command
-  // std::string cmd =
-  //     fmt::format("{} {} -n {} {}", get_python_executable(), get_gen_static_sig_script(), name, path);
-  // LOG(INFO) << "(Extracting Static Signature) Command: " << cmd;
-  // using json = nlohmann::json;
-  // std::string signature = execute_command(cmd);
-  // LOG(INFO) << "Output: " << signature;
-
-  // json j = json::parse(std::stringstream(signature));
-  // std::vector<int> arg_types_raw = j.get<std::vector<int>>();
-  // std::vector<ArgType> arg_types(arg_types_raw.size());
-  // std::transform(arg_types_raw.begin(), arg_types_raw.end(), arg_types.begin(), [](int tag) {
-  //   return ArgType(tag);
-  // });
-  // int num_args = arg_types.size();
-  // this->static_sig_ = StaticSignature {num_args, arg_types};
-  // LOG(INFO) << arg_types_raw;
-
   // embed python
   namespace py = pybind11;
-  // py::scoped_interpreter guard{};
-
-  auto tstate = PyGILState_Ensure();
-  pybind11::get_shared_data("");  // setup the internals pointer
-  PyGILState_Release(tstate);
-  pybind11::gil_scoped_acquire guard {};
+  ensure_initialized();
+  py::gil_scoped_acquire gil;
 
   std::filesystem::path script_dir = get_script_dir();
   py::module_ sys = py::module_::import("sys");
@@ -73,11 +60,8 @@ const TritonKernel& TritonJITFunction::get_kernel(std::string_view _signature,
   if (pos == this->overloads_.end()) {
     // embed python
     namespace py = pybind11;
-    // py::scoped_interpreter guard{};
-    auto tstate = PyGILState_Ensure();
-    pybind11::get_shared_data("");  // setup the internals pointer
-    PyGILState_Release(tstate);
-    pybind11::gil_scoped_acquire guard {};
+    ensure_initialized();
+    py::gil_scoped_acquire gil;
 
     std::filesystem::path script_dir = get_script_dir();
     py::module_ sys = py::module_::import("sys");

--- a/src/triton_jit_function.cpp
+++ b/src/triton_jit_function.cpp
@@ -77,26 +77,6 @@ const TritonKernel& TritonJITFunction::get_kernel(std::string_view _signature,
     std::string hash = ans.cast<std::string>();
     LOG(INFO) << "Output: " << hash;
 
-    // sys call
-    // std::string cmd = fmt::format(
-    //     "{} {} "
-    //     "--kernel-name {} "
-    //     "--signature {} "
-    //     "--num-warps {} --num-stages {} "
-    //     "--device-id {} "
-    //     "{}",
-    //     get_python_executable(),
-    //     get_standalone_compile_script(),
-    //     this->function_name_,
-    //     signature,
-    //     num_warps,
-    //     num_stages,
-    //     device_index,
-    //     this->file_path_);
-    // LOG(INFO) << "(JIT compiling) Command: " << cmd;
-    // std::string hash = execute_command(cmd);
-    // LOG(INFO) << "Output: " << hash;
-
     std::string kernel_dir = std::string(get_cache_path() / hash);
     TritonKernel kernel(kernel_dir, this->function_name_);
     LOG(INFO) << fmt::format("kernel_dir: {}", kernel_dir);


### PR DESCRIPTION
fix destruction: avoid using global static object

Now libtriton_jit depends on libpython. It has to ensure that python interpreter is initialized before executing python code.

Also, we initialize c10 Logging.

We add ensure_initialized into the constructor and get_kernel of TritonJITFunction to ensure that python interpreter is initialized.