### PR TITLE
add support for c10::Scalar, refactor argument handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,13 @@ endif()
 # --------------------------- subdirectories ---------------------------
 add_subdirectory(src)
 if(TRITON_JIT_BUILD_EXAMPLES)
+  set(INSTALL_GTEST OFF) # we do not install tests
+  FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG v1.16.0
+  )
+  FetchContent_MakeAvailable(googletest)
   add_subdirectory(examples)
 endif()
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(pointwise)
 add_subdirectory(reduce)
+add_subdirectory(arg_handle)

--- a/examples/arg_handle/CMakeLists.txt
+++ b/examples/arg_handle/CMakeLists.txt
@@ -1,0 +1,23 @@
+
+add_custom_target(
+    copy_triton_axpy_src
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${CMAKE_CURRENT_SOURCE_DIR}/axpy.py
+            ${CMAKE_CURRENT_BINARY_DIR}/axpy.py
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/axpy.py
+)
+
+add_library(axpy_op SHARED axpy_op.cpp)
+target_include_directories(axpy_op
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+)
+target_link_libraries(axpy_op
+    PUBLIC Torch::Torch
+    PRIVATE TritonJIT::triton_jit
+)
+add_dependencies(axpy_op copy_triton_axpy_src)
+
+add_executable(test_axpy test_axpy.cpp)
+target_link_libraries(test_axpy
+    PRIVATE axpy_op Torch::Torch GTest::gtest GTest::gtest_main)

--- a/examples/arg_handle/axpy.py
+++ b/examples/arg_handle/axpy.py
@@ -1,0 +1,49 @@
+import triton
+from triton import language as tl
+
+
+@triton.jit
+def axpy_kernel(X, Y, Out, a, n, BLOCK_N: tl.constexpr):
+    # ax + y
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_N + tl.arange(0, BLOCK_N)
+    mask = offsets < n
+
+    x = tl.load(X + offsets, mask=mask)
+    y = tl.load(Y + offsets, mask=mask)
+    o = a * x + y
+    tl.store(Out + offsets, o, mask=mask)
+
+
+@triton.jit
+def axpy2_kernel(X, Y, Out, a, n, BLOCK_N: tl.constexpr):
+    # ax + y
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_N + tl.arange(0, BLOCK_N)
+    mask = offsets < n
+
+    x = tl.load(X + offsets, mask=mask)
+    y = tl.load(Y + offsets, mask=mask)
+    if a is None:
+        o = x + y
+    else:
+        o = a * x + y
+    tl.store(Out + offsets, o, mask=mask)
+
+
+@triton.jit
+def axpy3_kernel(X, Y, Out, a, n, BLOCK_N: tl.constexpr):
+    # ax + y
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_N + tl.arange(0, BLOCK_N)
+    mask = offsets < n
+
+    x = tl.load(X + offsets, mask=mask)
+    o = x
+    if a is not None:
+        o *= a
+
+    if Y is not None:
+        y = tl.load(Y + offsets, mask=mask)
+        o += y
+    tl.store(Out + offsets, o, mask=mask)

--- a/examples/arg_handle/axpy_op.cpp
+++ b/examples/arg_handle/axpy_op.cpp
@@ -1,0 +1,112 @@
+
+
+#include "axpy_op.h"
+#include "c10/cuda/CUDAStream.h"
+#include "triton_jit/triton_jit_function.h"
+
+namespace my_ops {
+using namespace triton_jit;
+
+at::Tensor axpy(const at::Tensor &x, const at::Tensor &y, const c10::Scalar &alpha) {
+  auto res = torch::broadcast_tensors({x, y});
+  res[0] = res[0].contiguous();
+  res[1] = res[1].contiguous();
+  const at::Tensor &xx = res[0];
+  const at::Tensor &yy = res[1];
+
+  // TODO: consider weak-type of alpha here
+  at::ScalarType out_dtype = at::promote_types(x.scalar_type(), y.scalar_type());
+  at::Tensor out = at::empty(xx.sizes(), at::TensorOptions().dtype(out_dtype).device(x.device()));
+
+  const TritonJITFunction &f = TritonJITFunction::getInstance(std::string("axpy.py"), "axpy_kernel");
+
+  // add utility to build this automatically
+  int64_t tile_size = 1024;
+  const int num_warps = 8;
+  const int num_stages = 1;
+  int64_t n = out.numel();
+  const unsigned int num_blocks = (n + tile_size - 1) / tile_size;
+
+  // getCurrentCUDAStream ensures that the stream is initialized, a default stream for each device
+  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
+  c10::DeviceGuard guard(out.device());
+  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  f(raw_stream, num_blocks, 1, 1, num_warps, num_stages, x, y, out, alpha, n, tile_size);
+  return out;
+}
+
+at::Tensor axpy2(const at::Tensor &x, const at::Tensor &y, const std::optional<c10::Scalar> &alpha) {
+  auto res = torch::broadcast_tensors({x, y});
+  res[0] = res[0].contiguous();
+  res[1] = res[1].contiguous();
+  const at::Tensor &xx = res[0];
+  const at::Tensor &yy = res[1];
+
+  // TODO: consider weak-type of alpha here
+  at::ScalarType out_dtype = at::promote_types(x.scalar_type(), y.scalar_type());
+  at::Tensor out = at::empty(xx.sizes(), at::TensorOptions().dtype(out_dtype).device(x.device()));
+
+  const TritonJITFunction &f = TritonJITFunction::getInstance(std::string("axpy.py"), "axpy2_kernel");
+
+  // add utility to build this automatically
+  int64_t tile_size = 1024;
+  const int num_warps = 8;
+  const int num_stages = 1;
+  int64_t n = out.numel();
+  const unsigned int num_blocks = (n + tile_size - 1) / tile_size;
+
+  // getCurrentCUDAStream ensures that the stream is initialized, a default stream for each device
+  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
+  c10::DeviceGuard guard(out.device());
+  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  f(raw_stream, num_blocks, 1, 1, num_warps, num_stages, x, y, out, alpha, n, tile_size);
+  return out;
+}
+
+at::Tensor axpy3(const at::Tensor &x,
+                 const std::optional<at::Tensor> &y,
+                 const std::optional<c10::Scalar> &alpha) {
+  at::Tensor out = [&]() {
+    if (!y.has_value()) {
+      return at::empty_like(x);
+    } else {
+      auto res = torch::broadcast_tensors({x, y.value()});
+      res[0] = res[0].contiguous();
+      res[1] = res[1].contiguous();
+      const at::Tensor &xx = res[0];
+      const at::Tensor &yy = res[1];
+
+      // TODO: consider weak-type of alpha here
+      at::ScalarType out_dtype = at::promote_types(x.scalar_type(), y.value().scalar_type());
+      return at::empty(xx.sizes(), at::TensorOptions().dtype(out_dtype).device(x.device()));
+    }
+  }();
+  const TritonJITFunction &f = TritonJITFunction::getInstance(std::string("axpy.py"), "axpy3_kernel");
+
+  // add utility to build this automatically
+  int64_t tile_size = 1024;
+  const int num_warps = 8;
+  const int num_stages = 1;
+  int64_t n = out.numel();
+  const unsigned int num_blocks = (n + tile_size - 1) / tile_size;
+
+  // getCurrentCUDAStream ensures that the stream is initialized, a default stream for each device
+  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
+  c10::DeviceGuard guard(out.device());
+  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  f(raw_stream, num_blocks, 1, 1, num_warps, num_stages, x, y, out, alpha, n, tile_size);
+  return out;
+}
+
+TORCH_LIBRARY(my_ops, m) {
+  m.def("axpy(Tensor self, Tensor other, Scalar alpha) -> Tensor");
+  m.def("axpy2(Tensor self, Tensor other, Scalar? alpha) -> Tensor");
+  m.def("axpy3(Tensor self, Tensor? other, Scalar? alpha) -> Tensor");
+}
+
+TORCH_LIBRARY_IMPL(my_ops, CUDA, m) {
+  m.impl("axpy", TORCH_FN(axpy));
+  m.impl("axpy2", TORCH_FN(axpy2));
+  m.impl("axpy3", TORCH_FN(axpy3));
+}
+}  // namespace my_ops

--- a/examples/arg_handle/axpy_op.h
+++ b/examples/arg_handle/axpy_op.h
@@ -1,0 +1,15 @@
+
+
+#include <iostream>
+#include <optional>
+#include "torch/torch.h"
+
+namespace my_ops {
+
+at::Tensor axpy(const at::Tensor &x, const at::Tensor &y, const c10::Scalar &alpha);
+at::Tensor axpy2(const at::Tensor &x, const at::Tensor &y, const std::optional<c10::Scalar> &alpha);
+at::Tensor axpy3(const at::Tensor &x,
+                 const std::optional<at::Tensor> &y,
+                 const std::optional<c10::Scalar> &alpha);
+
+}  // namespace my_ops

--- a/examples/arg_handle/test_axpy.cpp
+++ b/examples/arg_handle/test_axpy.cpp
@@ -1,0 +1,72 @@
+
+#include <gtest/gtest.h>
+#include "axpy_op.h"
+#include "c10/cuda/CUDAFunctions.h"
+#include "torch/torch.h"
+
+TEST(arg_handle_test, scalar_int) {
+  at::Tensor a = at::rand({128 * 1024}, at::kCUDA);
+  at::Tensor b = at::rand({128 * 1024}, at::kCUDA);
+  // warm up
+  at::Tensor result1 = my_ops::axpy(a, b, c10::Scalar(10));
+  at::Tensor result2 = at::add(c10::Scalar(10) * a, b);
+  EXPECT_TRUE(torch::allclose(result1, result2));
+}
+
+TEST(arg_handle_test, scalar_double) {
+  at::Tensor a = at::rand({128 * 1024}, at::kCUDA);
+  at::Tensor b = at::rand({128 * 1024}, at::kCUDA);
+  // warm up
+  at::Tensor result1 = my_ops::axpy(a, b, c10::Scalar(3.14));
+  at::Tensor result2 = at::add(c10::Scalar(3.14) * a, b);
+  EXPECT_TRUE(torch::allclose(result1, result2));
+}
+
+TEST(arg_handle_test, optional_scalar_null_opt) {
+  at::Tensor a = at::rand({128 * 1024}, at::kCUDA);
+  at::Tensor b = at::rand({128 * 1024}, at::kCUDA);
+
+  std::optional<c10::Scalar> alpha = std::nullopt;
+  at::Tensor result1 = my_ops::axpy2(a, b, alpha);
+  at::Tensor result2 = at::add(a, b);
+  EXPECT_TRUE(torch::allclose(result1, result2));
+}
+
+TEST(arg_handle_test, optional_scalar_has_value) {
+  at::Tensor a = at::rand({128 * 1024}, at::kCUDA);
+  at::Tensor b = at::rand({128 * 1024}, at::kCUDA);
+
+  std::optional<c10::Scalar> alpha = c10::Scalar(3.14);
+  at::Tensor result1 = my_ops::axpy2(a, b, alpha);
+  at::Tensor result2 = at::add(alpha.value() * a, b);
+  EXPECT_TRUE(torch::allclose(result1, result2));
+}
+
+TEST(arg_handle_test, optional_scalar_bare_nullopt) {
+  at::Tensor a = at::rand({128 * 1024}, at::kCUDA);
+  at::Tensor b = at::rand({128 * 1024}, at::kCUDA);
+
+  at::Tensor result1 = my_ops::axpy2(a, b, std::nullopt);
+  at::Tensor result2 = at::add(a, b);
+  EXPECT_TRUE(torch::allclose(result1, result2));
+}
+
+TEST(arg_handle_test, optional_tensor_has_value) {
+  at::Tensor a = at::rand({128 * 1024}, at::kCUDA);
+  std::optional<at::Tensor> b = at::rand({128 * 1024}, at::kCUDA);
+
+  c10::Scalar alpha(3.14);
+  at::Tensor result1 = my_ops::axpy3(a, b, alpha);
+  at::Tensor result2 = at::add(alpha * a, b.value());
+  EXPECT_TRUE(torch::allclose(result1, result2));
+}
+
+TEST(arg_handle_test, optional_tensor_nullopt) {
+  at::Tensor a = at::rand({128 * 1024}, at::kCUDA);
+  std::optional<at::Tensor> b = std::nullopt;
+
+  c10::Scalar alpha(3.14);
+  at::Tensor result1 = my_ops::axpy3(a, b, alpha);
+  at::Tensor result2 = alpha * a;
+  EXPECT_TRUE(torch::allclose(result1, result2));
+}

--- a/include/triton_jit/jit_utils.h
+++ b/include/triton_jit/jit_utils.h
@@ -58,7 +58,20 @@ template <typename T>
 struct is_optional : public is_optional_helper<std::remove_const_t<std::remove_reference_t<T>>> {};
 
 template <typename T>
+struct is_scalar_helper : public std::false_type {};
+
+template <>
+struct is_scalar_helper<c10::Scalar> : public std::true_type {};
+
+template <typename T>
+struct is_scalar : public is_scalar_helper<std::remove_const_t<std::remove_reference_t<T>>> {};
+
+template <typename T>
 struct triton_type_helper;
+
+template <typename T, typename U>
+struct is_same_ignore_cvref : public std::is_same<std::remove_reference_t<std::remove_cv_t<T>>,
+                                                  std::remove_reference_t<std::remove_cv_t<U>>> {};
 
 #define DEFINE_TRITON_TYPE(T, Name)           \
   template <>                                 \
@@ -68,11 +81,12 @@ struct triton_type_helper;
 
 DEFINE_TRITON_TYPE(bool, "i1");
 DEFINE_TRITON_TYPE(int, "i32");
+DEFINE_TRITON_TYPE(uint, "u32");
 DEFINE_TRITON_TYPE(int64_t, "i64");
+DEFINE_TRITON_TYPE(uint64_t, "u64");
 DEFINE_TRITON_TYPE(float, "fp32");
 DEFINE_TRITON_TYPE(double, "fp64");
 DEFINE_TRITON_TYPE(std::nullptr_t, "*i8");
-DEFINE_TRITON_TYPE(std::nullopt_t, "*i8");
 
 #undef DEFINE_TRITON_TYPE
 

--- a/src/triton_kernel.cpp
+++ b/src/triton_kernel.cpp
@@ -39,7 +39,7 @@ void TritonKernel::lazy_init_handle(CUdevice device_index) const {
 
   CUmodule module;
   std::string cubin_path = fmt::format("{}/{}.cubin", this->dir_, this->kernel_name_);
-  LOG(INFO) << fmt::format("Loading cubin {} into {}", cubin_path, device_index);
+  LOG(INFO) << fmt::format("Loading cubin {} into device {}", cubin_path, device_index);
   checkCudaErrors(cuModuleLoad(&module, cubin_path.c_str()));
   this->modules_.emplace(device_index, module);
 }


### PR DESCRIPTION
1. Now libtriton_jit supports `c10::Scalar`, and `optional<T>`, including `optional<Tensor>`, `optional<Scalar>`, and other optional values.
2. Refactor argument handling.
3. Add examples in examples/arg_handle.
